### PR TITLE
Add GitHub Actions workflow for Cloudflare Pages deployment

### DIFF
--- a/.github/workflows/deploy-cf-pages.yml
+++ b/.github/workflows/deploy-cf-pages.yml
@@ -1,0 +1,52 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      
+      - name: Install Python dependencies
+        run: |
+          pip install -r requirements.txt
+      
+      - name: Install vendor builder dependencies
+        run: |
+          cd tools/vendor-builder
+          npm install
+      
+      - name: Build documentation
+        run: |
+          python build.py
+      
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: phantom-documentation-kit
+          directory: outputs/www
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.head_ref || github.ref_name }}
+          wranglerVersion: '3'


### PR DESCRIPTION
- Setup Python 3.12 and Node.js 22 environments
- Install dependencies for both Python and vendor builder
- Use build.py to generate static site in outputs/www
- Deploy to existing Cloudflare Pages project: phantom-documentation-kit
- Support push to main, PR, and manual workflow dispatch